### PR TITLE
Copy GeoIp2 City Database

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -23,6 +23,9 @@ GEOIP_DATA_DIR="$BUILD_DIR/geoip_data"
 GEOLITECOUNTRY_URL="http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz"
 GEOLITECOUNTRY_FILE="GeoLite2-Country.mmdb"
 
+GEOLITECITY_URL="http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz"
+GEOLITECITY_FILE="GeoLite2-City.mmdb"
+
 VENDORED_GEOIP=".geoip/$GEOIP_VERSION"
 
 
@@ -65,4 +68,10 @@ if [ ! -f $GEOLITECOUNTRY_FILE ]; then
     puts-step "Adding GeoIP2 country database"
     curl -s -L -o ${GEOLITECOUNTRY_FILE}.gz $GEOLITECOUNTRY_URL
     gunzip ${GEOLITECOUNTRY_FILE}.gz > /dev/null
+fi
+
+if [ ! -f $GEOLITECITY_FILE ]; then
+    puts-step "Adding GeoIP2 city database"
+    curl -s -L -o ${GEOLITECITY_FILE}.gz $GEOLITECITY_URL
+    gunzip ${GEOLITECITY_FILE}.gz > /dev/null
 fi


### PR DESCRIPTION
Added steps to copy the GeoIp2 city database (as well as the country …db) into target app directory.